### PR TITLE
Unify Pulsar image

### DIFF
--- a/config/assets/charts/pulsar/values.yaml
+++ b/config/assets/charts/pulsar/values.yaml
@@ -623,7 +623,7 @@ pulsar_metadata:
   component: pulsar-init
   image:
     # the image used for running `pulsar-cluster-initialize` job
-    repository: apachepulsar/pulsar-all
+    repository: apachepulsar/pulsar
     tag: 2.7.3
     pullPolicy: IfNotPresent
   ## set an existing configuration store


### PR DESCRIPTION
#51  use `pulsar` image instead of `pulsar-all`.

The `pulsar-all` only add puslar connectors & offloads in `pulsar` which will not be used in our deploy.

Ref: see diffs between [pulsar-all image layers](https://hub.docker.com/layers/apachepulsar/pulsar-all/2.7.3/images/sha256-788c0ffb3ec6cc44031945925374662d2613c58842a3472f94c99c645671a11e?context=explore) and [pulsar image layers](https://hub.docker.com/layers/apachepulsar/pulsar/2.7.3/images/sha256-f858f9535668032db9d18c33b398b60a678696b944241c5213e4466f46c18fa7?context=explore), line 23, 24

/cc @zwd1208 