### PR TITLE
Feature:  certmanager check can be disabled in helm chart

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 IMG ?= milvusdb/milvus-operator:dev-latest
 RELEASE_IMG ?= milvusdb/milvus-operator:latest
 SIT_IMG ?= milvus-operator:sit
-VERSION ?= 0.3.2
+VERSION ?= 0.3.3
 MILVUS_HELM_VERSION ?= milvus-3.0.0
 
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)

--- a/charts/milvus-operator/Chart.yaml
+++ b/charts/milvus-operator/Chart.yaml
@@ -18,13 +18,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.1
+version: 0.1.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.3.2"
+appVersion: "0.3.3"
 
 maintainers:
   - name: devops team of zilliz

--- a/charts/milvus-operator/templates/job.yaml
+++ b/charts/milvus-operator/templates/job.yaml
@@ -18,6 +18,12 @@ spec:
         args:
           - "-namespace={{ .Release.Namespace }}"
           - "-name={{ .Release.Name }}"
+          {{- if .Values.checker.disableCertManagerCheck }}
+          - "-disable-cert-manager-check"
+          {{- end }}
+          {{- if .Values.checker.disableCertManagerInstall }}
+          - "-disable-cert-manager-install"
+          {{- end }}
         resources:
           limits:
             cpu: 500m

--- a/charts/milvus-operator/values.yaml
+++ b/charts/milvus-operator/values.yaml
@@ -12,6 +12,10 @@ image:
 # installCRDs -- If true, CRD resources will be installed as part of the Helm chart. If enabled, when uninstalling CRD resources will be deleted causing all installed custom resources to be DELETED
 installCRDs: true
 
+checker:
+  disableCertManagerCheck: false
+  disableCertManagerInstall: false
+
 # check and install the dependencies when enabled, this need an extra service account with privileged clusterroles
 installDependencies:
   enable: true

--- a/config/dev/kustomization.yaml
+++ b/config/dev/kustomization.yaml
@@ -4,14 +4,3 @@ resources:
 
 patchesStrategicMerge:
 - manager_dev_patch.yaml
-
-#patches:
-#- patch: |
-#    - op: "remove"
-#      path: "/spec/template/spec/containers/0"
-#      value: "https://host.docker.internal:9443/mutate-milvus-io-v1alpha1-milvuscluster"
-#  target:
-#    kind: Deployment
-#    name: milvus-operator-controller-manager
-#    namespace: milvus-operator
-#    labelSelector: "control-plane=controller-manager"

--- a/pkg/provisioner/cert_manager.go
+++ b/pkg/provisioner/cert_manager.go
@@ -32,8 +32,10 @@ func certManagerManifestURLByVersion(version string) string {
 // configs is set by flag in main.go
 var (
 	CertManagerLeastSemanticVersion        = semver.New(strings.TrimPrefix(CertManagerLeastVersion, "v"))
-	InstallCertManagerIfNotExist    bool   = true
-	InstallCertManagerFlag          string = "install-cert-manager"
+	DisableCertManagerCheck         bool   = false
+	DisableCertManagerCheckFlag     string = "disable-cert-manager-check"
+	DisableCertManagerInstall       bool   = false
+	DisableCertManagerInstallFlag   string = "disable-cert-manager-install"
 	logger                                 = ctrl.Log.WithName("cert-manager")
 )
 
@@ -80,8 +82,8 @@ func (c CertManager) checkAndInstall() error {
 		}
 		return errors.Errorf("cert manager crds exist but version is too old, please update it manually")
 	}
-	if !InstallCertManagerIfNotExist {
-		return errors.Errorf("cert manager crds not exist, please install it manually, or enable -%s flag", InstallCertManagerFlag)
+	if DisableCertManagerInstall {
+		return errors.Errorf("cert manager crds not exist, please install it manually, or enable -%s flag", DisableCertManagerInstallFlag)
 	}
 	return errors.Wrap(c.installCertManager(), "failed to install cert manager")
 }

--- a/pkg/provisioner/cert_manager_test.go
+++ b/pkg/provisioner/cert_manager_test.go
@@ -29,7 +29,14 @@ func TestCertManager_InstallIfNotExist(t *testing.T) {
 	ret, err := NewCertManager(config)
 	assert.NoError(t, err)
 
+	t.Run("install disabled, install failed", func(t *testing.T) {
+		DisableCertManagerInstall = true
+		err = ret.InstallIfNotExist()
+		assert.Error(t, err)
+	})
+
 	// install ok
+	DisableCertManagerInstall = false
 	err = ret.InstallIfNotExist()
 	assert.NoError(t, err)
 

--- a/tool/checker/main.go
+++ b/tool/checker/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"log"
 
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
@@ -15,14 +16,19 @@ import (
 func main() {
 	flag.StringVar(&config.OperatorNamespace, "namespace", "milvus-operator", "The namespace of self")
 	flag.StringVar(&config.OperatorName, "name", "milvus-operator-controller-manager", "The namespace of self")
-	flag.BoolVar(&provisioner.InstallCertManagerIfNotExist, provisioner.InstallCertManagerFlag, true, "Install cert-manager if not exist")
+	flag.BoolVar(&provisioner.DisableCertManagerInstall, provisioner.DisableCertManagerInstallFlag, provisioner.DisableCertManagerInstall, "Disable auto install cert-manager if not exist")
+	flag.BoolVar(&provisioner.DisableCertManagerCheck, provisioner.DisableCertManagerCheckFlag, provisioner.DisableCertManagerCheck, "Disable auto check & install cert-manager")
 	certMangerProvisioner, err := provisioner.NewCertManager(ctrlConfig.GetConfigOrDie())
 	if err != nil {
 		log.Fatal("unable to create cert manager provisioner ", err)
 	}
-	err = certMangerProvisioner.InstallIfNotExist()
-	if err != nil {
-		log.Fatal("unable to install cert manager ", err)
+	if !provisioner.DisableCertManagerCheck {
+		err = certMangerProvisioner.InstallIfNotExist()
+		if err != nil {
+			log.Fatal("unable to install cert manager ", err)
+		}
+	} else {
+		fmt.Println("cert-manager check is skipped")
 	}
 
 	err = certMangerProvisioner.IssueCertIfNotExist()


### PR DESCRIPTION
- certmanager check can be disabled in helm chart  
- helm chart can also disable auto install certmanager & leave it to human
- bump version of operator & helm chart

Signed-off-by: shaoyue.chen <shaoyue.chen@zilliz.com>
/cc @zwd1208 