### PR TITLE
WIP:add Reconcile ingress to exposed milvus service for CRD milvus

### DIFF
--- a/pkg/controllers/ingress.go
+++ b/pkg/controllers/ingress.go
@@ -1,0 +1,97 @@
+package controllers
+
+import (
+	"context"
+	"github.com/milvus-io/milvus-operator/apis/milvus.io/v1alpha1"
+	networkingv1 "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+var ingressClass = "nginx"
+var pathTypePrefix = networkingv1.PathTypePrefix
+var host = "milvus.proxy.com"
+
+
+func (r *MilvusReconciler) ReconcileIngress(ctx context.Context, mil v1alpha1.Milvus) error {
+
+	namespacedName := NamespacedName(mil.Namespace, mil.Name)
+	old := &networkingv1.Ingress{}
+	err := r.Get(ctx, namespacedName, old)
+	if errors.IsNotFound(err) {
+		new := &networkingv1.Ingress{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      namespacedName.Name,
+				Namespace: namespacedName.Namespace,
+				Annotations: map[string]string{
+					"nginx.ingress.kubernetes.io/backend-protocol": "GRPC",
+				},
+			},
+		}
+		if err := r.updateIngress(mil, new,namespacedName.Name); err != nil {
+			return err
+		}
+
+		r.logger.Info("Create Ingress", "name", new.Name, "namespace", new.Namespace)
+		return r.Create(ctx, new)
+	} else if err != nil {
+		return err
+	}
+
+	cur := old.DeepCopy()
+	if err := r.updateIngress(mil, cur,namespacedName.Name); err != nil {
+		return err
+	}
+
+	if IsEqual(old, cur) {
+		return nil
+	}
+
+	r.logger.Info("Update Ingress", "name", cur.Name, "namespace", cur.Namespace)
+	return r.Update(ctx, cur)
+}
+
+func (r *MilvusReconciler) updateIngress(
+	mc v1alpha1.Milvus, ingress *networkingv1.Ingress, name string,
+) error {
+
+	if err := ctrl.SetControllerReference(&mc, ingress, r.Scheme); err != nil {
+		return err
+	}
+
+	ingress.Spec.IngressClassName = &ingressClass
+	ingress.Spec.TLS =  []networkingv1.IngressTLS{
+		{
+			SecretName: "milvus-secret",
+			Hosts: []string{host},
+		},
+
+	}
+	ingress.Spec.Rules = []networkingv1.IngressRule{
+		{
+			Host: host,
+			IngressRuleValue: networkingv1.IngressRuleValue{
+				HTTP: &networkingv1.HTTPIngressRuleValue{
+					Paths: []networkingv1.HTTPIngressPath{
+						{
+							Path:     "/",
+							PathType: &pathTypePrefix,
+							Backend: networkingv1.IngressBackend{
+								Service: &networkingv1.IngressServiceBackend{
+									Name: name,
+									Port: networkingv1.ServiceBackendPort{
+										Number: 19530,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+
+	return nil
+}

--- a/pkg/controllers/milvus.go
+++ b/pkg/controllers/milvus.go
@@ -129,6 +129,7 @@ func (r *MilvusReconciler) ReconcileMilvus(ctx context.Context, mil v1alpha1.Mil
 	milvusComsReconcilers := []Func{
 		r.ReconcileDeployments,
 		r.ReconcileServices,
+		r.ReconcileIngress,
 		r.ReconcilePodMonitor,
 	}
 	err := defaultGroupRunner.Run(milvusComsReconcilers, ctx, mil)

--- a/pkg/controllers/milvus_test.go
+++ b/pkg/controllers/milvus_test.go
@@ -197,7 +197,7 @@ func TestMilvus_ReconcileMilvus(t *testing.T) {
 			Return(k8sErrors.NewNotFound(schema.GroupResource{}, "mockErr")),
 		mockClient.EXPECT().
 			Create(gomock.Any(), gomock.Any()).Return(nil),
-		mockGroup.EXPECT().Run(gomock.Len(3), gomock.Any(), m),
+		mockGroup.EXPECT().Run(gomock.Len(4), gomock.Any(), m),
 	)
 
 	err = r.ReconcileMilvus(ctx, m)

--- a/pkg/controllers/milvuscluster_test.go
+++ b/pkg/controllers/milvuscluster_test.go
@@ -208,7 +208,7 @@ func TestCluster_ReconcileMilvus(t *testing.T) {
 			Return(k8sErrors.NewNotFound(schema.GroupResource{}, "mockErr")),
 		mockClient.EXPECT().
 			Create(gomock.Any(), gomock.Any()).Return(nil),
-		mockGroup.EXPECT().Run(gomock.Len(3), gomock.Any(), m),
+		mockGroup.EXPECT().Run(gomock.Len(4), gomock.Any(), m),
 	)
 
 	err = r.ReconcileMilvus(ctx, m)


### PR DESCRIPTION
### add ingress controller 
Before we start use ingress,we should install ingress-controller,so the doc (https://milvus.io/docs/v2.0.x/install_cluster-milvusoperator.md)  need update

Prerequisites add 

2. install ingress-controller 
kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v1.1.1/deploy/static/provider/cloud/deploy.yaml

<img width="957" alt="image" src="https://user-images.githubusercontent.com/8857976/156861176-2b44c26b-f65e-4b20-ba8c-623b4f846387.png">

### add secret milvus-secret 

```
openssl req -x509 -nodes -days 3650 -newkey rsa:2048 -keyout sslforingress.key -out sslforingress.pem -subj "/CN=grpc.test.com"

kubectl create secret tls milvus-secret  --cert sslforingress.pem --key sslforingress.key -n default
```

Below is an example of an ingress resource：

```
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  annotations:
    nginx.ingress.kubernetes.io/backend-protocol: "GRPC"
  name: ingress-milvus-host
  namespace: default
spec:
  ingressClassName: nginx
  rules:
  - host: milvus.proxy.com
    http:
      paths:
      - path: /
        pathType: Prefix
        backend:
          service:
            name: my-release2-milvus
            port:
              number: 19530
  tls:
  # This secret must exist beforehand
  # The cert must also contain the subj-name grpctest.dev.mydomain.com
  # https://github.com/kubernetes/ingress-nginx/blob/master/docs/examples/PREREQUISITES.md#tls-certificates
  - secretName: milvus-secret 
    hosts:
      - milvus.proxy.com
```

### Reference link
* https://blog.csdn.net/cloudvtech/article/details/106058828
* https://kubernetes.github.io/ingress-nginx/deploy/

