### PR TITLE
fix UpdateIngressStatus for MilvusCluster

### DIFF
--- a/pkg/controllers/status_cluster.go
+++ b/pkg/controllers/status_cluster.go
@@ -209,6 +209,13 @@ func getComponentDeployment(ctx context.Context, key client.ObjectKey, component
 }
 
 func (r *MilvusStatusSyncer) UpdateIngressStatus(ctx context.Context, mc *v1beta1.Milvus) error {
+	ingress := mc.Spec.Com.Standalone.Ingress
+	if mc.Spec.Mode == v1beta1.MilvusModeCluster {
+		ingress = mc.Spec.Com.Proxy.Ingress
+	}
+	if ingress == nil {
+		return nil
+	}
 	key := client.ObjectKeyFromObject(mc)
 	key.Name = key.Name + "-milvus"
 	status, err := getIngressStatus(ctx, r.Client, client.ObjectKeyFromObject(mc))


### PR DESCRIPTION
issue: https://github.com/milvus-io/milvus-operator/issues/130
===
# log information
### before
```log
2022-05-16T11:06:54.495Z        INFO    controller.status-syncer        loopfunc end    {"func": "syncUnhealthy-fm"}
2022-05-16T11:07:22.040Z        INFO    controller.status-syncer        loopfunc run    {"func": "syncUnhealthy-fm"}
2022-05-16T11:07:22.040Z        INFO    controller.status-syncer        syncUnhealthy mc status {"status": "Creating"}
2022-05-16T11:07:24.396Z        INFO    controller.milvus-cluster       start reconcile
2022-05-16T11:07:24.395Z        ERROR   controller.status-syncer        loopFunc err    {"func": "syncUnhealthy-fm", "error": "UpdateStatus failed: run group failed: groups error: update ingress status failed: get ingress status failed: no matches for kind \"Ingress\" in version \"networking.k8s.io/v1\"", "errorVerbose": "groups error: update ingress status failed: get ingress status failed: no matches for kind \"Ingress\" inversion \"networking.k8s.io/v1\"\ngithub.com/milvus-io/milvus-operator/pkg/controllers.(*Group).Wait\n\t/workspace/pkg/controllers/groups.go:85\ngithub.com/milvus-io/milvus-operator/pkg/controllers.ParallelGroupRunner.RunDiffArgs\n\t/workspace/pkg/controllers/group_runner.go:115\ngithub.com/milvus-io/milvus-operator/pkg/controllers.(*MilvusClusterStatusSyncer).syncUnhealthy\n\t/workspace/pkg/controllers/status_cluster.go:92\ngithub.com/milvus-io/milvus-operator/pkg/controllers.LoopWithInterval\n\t/workspace/pkg/controllers/utils.go:405\nruntime.goexit\n\t/usr/local/go/src/runtime/asm_amd64.s:1371\nrun group failed\ngithub.com/milvus-io/milvus-operator/pkg/controllers.ParallelGroupRunner.RunDiffArgs\n\t/workspace/pkg/controllers/group_runner.go:116\ngithub.com/milvus-io/milvus-operator/pkg/controllers.(*MilvusClusterStatusSyncer).syncUnhealthy\n\t/workspace/pkg/controllers/status_cluster.go:92\ngithub.com/milvus-io/milvus-operator/pkg/controllers.LoopWithInterval\n\t/workspace/pkg/controllers/utils.go:405\nruntime.goexit\n\t/usr/local/go/src/runtime/asm_amd64.s:1371\nUpdateStatus failed\ngithub.com/milvus-io/milvus-operator/pkg/controllers.(*MilvusClusterStatusSyncer).syncUnhealthy\n\t/workspace/pkg/controllers/status_cluster.go:93\ngithub.com/milvus-io/milvus-operator/pkg/controllers.LoopWithInterval\n\t/workspace/pkg/controllers/utils.go:405\nruntime.goexit\n\t/usr/local/go/src/runtime/asm_amd64.s:1371"}
2022-05-16T11:07:24.397Z        INFO    controller.status-syncer        loopfunc end    {"func": "syncUnhealthy-fm"}
```
### after
```log
2022-05-16T11:18:08.789Z        INFO    controller.milvus-cluster       start reconcile
2022-05-16T11:18:08.831Z        INFO    controller.milvus-cluster       start reconcile
2022-05-16T11:18:08.832Z        INFO    controller.status-syncer        loopfunc end    {"func": "syncUnhealthy-fm"}
2022-05-16T11:18:09.935Z        INFO    controller.milvus-cluster       Create Configmap        {"name": "milvuscluster", "namespace": "milvus-operator"}
```