### PR TITLE
milvus default version to 2.1.1, bump version to 0.6.4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # Image URL to use all building/pushing image targets
 IMG ?= milvusdb/milvus-operator:dev-latest
 SIT_IMG ?= milvus-operator:sit
-VERSION ?= 0.6.3
+VERSION ?= 0.6.4
 MILVUS_HELM_VERSION ?= milvus-3.1.9
 RELEASE_IMG ?= milvusdb/milvus-operator:v$(VERSION)
 
@@ -207,7 +207,7 @@ sit-prepare-operator-images:
 
 sit-prepare-images: sit-prepare-operator-images
 	@echo "Preparing images"
-	docker pull milvusdb/milvus:v2.1.0
+	docker pull milvusdb/milvus:v2.1.1
 	
 	docker pull -q apachepulsar/pulsar:2.8.2
 	docker pull -q bitnami/kafka:3.1.0-debian-10-r52
@@ -225,7 +225,7 @@ sit-load-operator-images:
 
 sit-load-images: sit-load-operator-images
 	@echo "Loading images"
-	kind load docker-image milvusdb/milvus:v2.1.0
+	kind load docker-image milvusdb/milvus:v2.1.1
 	kind load docker-image apachepulsar/pulsar:2.8.2
 	kind load docker-image bitnami/kafka:3.1.0-debian-10-r52
 	kind load docker-image milvusdb/etcd:3.5.0-r6

--- a/README.md
+++ b/README.md
@@ -21,13 +21,13 @@ Install with helm:
 ```shell
 helm install milvus-operator \
   -n milvus-operator --create-namespace \
-  https://github.com/milvus-io/milvus-operator/releases/download/v0.6.3/milvus-operator-0.6.3.tgz
+  https://github.com/milvus-io/milvus-operator/releases/download/v0.6.4/milvus-operator-0.6.4.tgz
 ```
 
 Or install with kubectl & raw manifests:
 
 ```shell
-kubectl apply -f https://raw.githubusercontent.com/milvus-io/milvus-operator/v0.6.3/deploy/manifests/deployment.yaml
+kubectl apply -f https://raw.githubusercontent.com/milvus-io/milvus-operator/v0.6.4/deploy/manifests/deployment.yaml
 ```
 
 For more infomation Check [instructions on how to install/uninstall milvus operator](docs/installation/installation.md)
@@ -43,11 +43,11 @@ Versions of the underlying components are listed below:
 
 <!-- source csv for table
 Components, Milvus, Pulsar / Kafka, Etcd, MinIO
-Versions, v2.1.0 `[1]`, 2.8.2 / 3.1.0, 3.5.0, RELEASE.2022-03-17T06-34-49Z -->
+Versions, v2.1.1 `[1]`, 2.8.2 / 3.1.0, 3.5.0, RELEASE.2022-03-17T06-34-49Z -->
 
 |Components| Milvus| Pulsar / Kafka| Etcd| MinIO|
 |---|---|---|---|---|
-|Versions| v2.1.0 `[1]`| 2.8.2 / 3.1.0 | 3.5.0|RELEASE.2022-03-17T06-34-49Z|
+|Versions| v2.1.1 `[1]`| 2.8.2 / 3.1.0 | 3.5.0|RELEASE.2022-03-17T06-34-49Z|
 
 
 **NOTES:**

--- a/charts/milvus-operator/Chart.yaml
+++ b/charts/milvus-operator/Chart.yaml
@@ -18,13 +18,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.3
+version: 0.6.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.6.3"
+appVersion: "0.6.4"
 
 maintainers:
   - name: devops team of zilliz

--- a/charts/milvus-operator/values.yaml
+++ b/charts/milvus-operator/values.yaml
@@ -7,7 +7,7 @@ image:
   # image.pullPolicy -- The image pull policy for the controller.
   pullPolicy: IfNotPresent
   # image.tag -- The image tag whose default is the chart appVersion.
-  tag: "v0.6.3"
+  tag: "v0.6.4"
 
 # installCRDs -- If true, CRD resources will be installed as part of the Helm chart. If enabled, when uninstalling CRD resources will be deleted causing all installed custom resources to be DELETED
 installCRDs: true

--- a/deploy/manifests/deployment.yaml
+++ b/deploy/manifests/deployment.yaml
@@ -11,10 +11,10 @@ metadata:
   name: "milvus-operator"
   namespace: "milvus-operator"
   labels:
-    helm.sh/chart: milvus-operator-0.6.3
+    helm.sh/chart: milvus-operator-0.6.4
     app.kubernetes.io/name: milvus-operator
     app.kubernetes.io/instance: milvus-operator
-    app.kubernetes.io/version: "0.6.3"
+    app.kubernetes.io/version: "0.6.4"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: milvus-operator/templates/serviceaccount.yaml
@@ -24,10 +24,10 @@ metadata:
   name: "milvus-operator-checker"
   namespace: "milvus-operator"
   labels:
-    helm.sh/chart: milvus-operator-0.6.3
+    helm.sh/chart: milvus-operator-0.6.4
     app.kubernetes.io/name: milvus-operator
     app.kubernetes.io/instance: milvus-operator
-    app.kubernetes.io/version: "0.6.3"
+    app.kubernetes.io/version: "0.6.4"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: milvus-operator/templates/crds.yaml
@@ -13693,10 +13693,10 @@ kind: Service
 metadata:
   labels:
     service-kind: metrics
-    helm.sh/chart: milvus-operator-0.6.3
+    helm.sh/chart: milvus-operator-0.6.4
     app.kubernetes.io/name: milvus-operator
     app.kubernetes.io/instance: milvus-operator
-    app.kubernetes.io/version: "0.6.3"
+    app.kubernetes.io/version: "0.6.4"
     app.kubernetes.io/managed-by: Helm
   name: 'milvus-operator-metrics-service'
   namespace: "milvus-operator"
@@ -13714,10 +13714,10 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: milvus-operator-0.6.3
+    helm.sh/chart: milvus-operator-0.6.4
     app.kubernetes.io/name: milvus-operator
     app.kubernetes.io/instance: milvus-operator
-    app.kubernetes.io/version: "0.6.3"
+    app.kubernetes.io/version: "0.6.4"
     app.kubernetes.io/managed-by: Helm
   name: 'milvus-operator-webhook-service'
   namespace: "milvus-operator"
@@ -13736,10 +13736,10 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: milvus-operator-0.6.3
+    helm.sh/chart: milvus-operator-0.6.4
     app.kubernetes.io/name: milvus-operator
     app.kubernetes.io/instance: milvus-operator
-    app.kubernetes.io/version: "0.6.3"
+    app.kubernetes.io/version: "0.6.4"
     app.kubernetes.io/managed-by: Helm
   name: "milvus-operator"
   namespace: "milvus-operator"
@@ -13769,7 +13769,7 @@ spec:
         - --leader-elect
         command:
         - /manager
-        image: 'milvusdb/milvus-operator:v0.6.3'
+        image: 'milvusdb/milvus-operator:v0.6.4'
         imagePullPolicy: "IfNotPresent"
         livenessProbe:
           httpGet:
@@ -13824,10 +13824,10 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   labels:
-    helm.sh/chart: milvus-operator-0.6.3
+    helm.sh/chart: milvus-operator-0.6.4
     app.kubernetes.io/name: milvus-operator
     app.kubernetes.io/instance: milvus-operator
-    app.kubernetes.io/version: "0.6.3"
+    app.kubernetes.io/version: "0.6.4"
     app.kubernetes.io/managed-by: Helm
   name: "milvus-operator-checker"
   namespace: "milvus-operator"
@@ -13841,7 +13841,7 @@ spec:
       restartPolicy: OnFailure
       containers:
       - name: checker
-        image: 'milvusdb/milvus-operator:v0.6.3'
+        image: 'milvusdb/milvus-operator:v0.6.4'
         imagePullPolicy: "IfNotPresent"
         command: ["/checker"]
         args:

--- a/docs/installation/installation.md
+++ b/docs/installation/installation.md
@@ -13,7 +13,7 @@ For quick start, install with one line command:
 ```shell
 helm install milvus-operator \
   -n milvus-operator --create-namespace \
-  https://github.com/milvus-io/milvus-operator/releases/download/v0.6.3/milvus-operator-0.6.3.tgz
+  https://github.com/milvus-io/milvus-operator/releases/download/v0.6.4/milvus-operator-0.6.4.tgz
 ```
 
 If you already have `cert-manager` v1.0+ installed which is not in its default configuration, you may encounter some error with the check of cert-manager installation. you can install with special options to disable the check:
@@ -21,7 +21,7 @@ If you already have `cert-manager` v1.0+ installed which is not in its default c
 ```
 helm install milvus-operator \
   -n milvus-operator --create-namespace \
-  https://github.com/milvus-io/milvus-operator/releases/download/v0.6.3/milvus-operator-0.6.3.tgz \
+  https://github.com/milvus-io/milvus-operator/releases/download/v0.6.4/milvus-operator-0.6.4.tgz \
   --set checker.disableCertManagerCheck=true
 ```
 
@@ -40,7 +40,7 @@ use helm commands to upgrade earlier milvus-operator to current version:
 
 ```shell
 helm upgrade -n milvus-operator milvus-operator --reuse-values \
-  https://github.com/milvus-io/milvus-operator/releases/download/v0.6.3/milvus-operator-0.6.3.tgz
+  https://github.com/milvus-io/milvus-operator/releases/download/v0.6.4/milvus-operator-0.6.4.tgz
 ```
 
 ## Delete operator

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	DefaultMilvusVersion   = "v2.1.0"
+	DefaultMilvusVersion   = "v2.1.1"
 	DefaultMilvusBaseImage = "milvusdb/milvus"
 	DefaultMilvusImage     = DefaultMilvusBaseImage + ":" + DefaultMilvusVersion
 	DefaultImagePullPolicy = corev1.PullIfNotPresent

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -1,18 +1,33 @@
 #!/bin/bash
 set -ex
+
+# usage: bump-version.sh <milvus-operator-version> <milvus-version> <milvus-helm-version>
+
+# semantic version without v, e.g. 1.2.3
 OPERATOR_VERSION=$1
-MILVUS_HELM_VERSION=$2
+MILVUS_VERSION=$2
+MILVUS_HELM_VERSION=$3
 
 SED="sed -i"
 if [[ "$(go env GOOS)" == "darwin" ]]; then
     SED="sed -i .bak "
 fi
+
+# operator version
 ${SED} "s/^VERSION ?= .*/VERSION ?= ${OPERATOR_VERSION}/g" ./Makefile
-${SED} "s/^MILVUS_HELM_VERSION ?= milvus-.*/MILVUS_HELM_VERSION ?= milvus-${MILVUS_HELM_VERSION}/g" ./Makefile
 ${SED} "s/^version: .*/version: ${OPERATOR_VERSION}/g" ./charts/milvus-operator/Chart.yaml
 ${SED} "s/^appVersion: .*/appVersion: \"${OPERATOR_VERSION}\"/g" ./charts/milvus-operator/Chart.yaml
 ${SED} "s/^  tag: \".*\"/  tag: \"v${OPERATOR_VERSION}\"/g" ./charts/milvus-operator/values.yaml
 ${SED} "s|milvus-operator/releases/download/.*/milvus-operator-.*.tgz|milvus-operator/releases/download/v${OPERATOR_VERSION}/milvus-operator-${OPERATOR_VERSION}.tgz|g" ./README.md ./docs/installation/installation.md
 ${SED} "s|milvus-operator/.*/deploy/manifests/deployment.yaml|milvus-operator/v${OPERATOR_VERSION}/deploy/manifests/deployment.yaml|g" ./README.md
+
+# milvus version
+${SED} "s|milvusdb/milvus:.*|milvusdb/milvus:v${MILVUS_VERSION}|g" ./Makefile
+${SED} "s/Versions, v.* \`/Versions, v${MILVUS_VERSION} \`/g" ./README.md
+${SED} "s/Versions| v.* \`/Versions| v${MILVUS_VERSION} \`/g" ./README.md
+${SED} "s/DefaultMilvusVersion   = \"v.*\"/DefaultMilvusVersion   = \"v${MILVUS_VERSION}\"/g" ./pkg/config/config.go
+# milvus-helm version
+${SED} "s/^MILVUS_HELM_VERSION ?= milvus-.*/MILVUS_HELM_VERSION ?= milvus-${MILVUS_HELM_VERSION}/g" ./Makefile
+
 
 make deploy-manifests


### PR DESCRIPTION
- milvus default version to 2.1.1, bump version to 0.6.4
- `scripts/bump-version.sh` supports change milvus version