### PR TITLE
Helm chart now obeys imagePullSecrets value

### DIFF
--- a/charts/milvus-operator/Chart.yaml
+++ b/charts/milvus-operator/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.7.5
+version: 0.7.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/milvus-operator/templates/deployment.yaml
+++ b/charts/milvus-operator/templates/deployment.yaml
@@ -54,6 +54,10 @@ spec:
         - mountPath: /tmp/k8s-webhook-server/serving-certs
           name: cert
           readOnly: true
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       nodeSelector: {{- toYaml .Values.nodeSelector | nindent 8 }}
       securityContext: {{- toYaml .Values.podSecurityContext | nindent 8 }}
       serviceAccountName: {{ include "chart.serviceAccountName" . | quote }}

--- a/charts/milvus-operator/templates/job.yaml
+++ b/charts/milvus-operator/templates/job.yaml
@@ -35,3 +35,7 @@ spec:
             memory: 100Mi
         securityContext:
           allowPrivilegeEscalation: false
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}


### PR DESCRIPTION
- The advertized `imagePullSecrets` field in the Helm chart's values.yaml was not actually used anywhere. Now, it is obeyed both in the Deployment for milvus-operator as well as the "checker" Job. This is especially important for people who use private Docker registries or mirrors.