### PR TITLE
Revert "Bump default milvus version to 2.2.6, operator to 0.7.10 (#240)"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 IMG ?= milvusdb/milvus-operator:dev-latest
 TOOL_IMG ?= milvus-config-tool:dev-latest
 SIT_IMG ?= milvus-operator:sit
-VERSION ?= 0.7.10
+VERSION ?= 0.7.9
 TOOL_VERSION ?= 0.1.1
 MILVUS_HELM_VERSION ?= milvus-4.0.13
 RELEASE_IMG ?= milvusdb/milvus-operator:v$(VERSION)
@@ -228,7 +228,7 @@ sit-prepare-operator-images:
 
 sit-prepare-images: sit-prepare-operator-images
 	@echo "Preparing images"
-	docker pull milvusdb/milvus:v2.2.6
+	docker pull milvusdb/milvus:v2.2.5
 	
 	docker pull -q apachepulsar/pulsar:2.8.2
 	docker pull -q bitnami/kafka:3.1.0-debian-10-r52
@@ -246,7 +246,7 @@ sit-load-operator-images:
 
 sit-load-images: sit-load-operator-images
 	@echo "Loading images"
-	kind load docker-image milvusdb/milvus:v2.2.6
+	kind load docker-image milvusdb/milvus:v2.2.5
 	kind load docker-image apachepulsar/pulsar:2.8.2
 	kind load docker-image bitnami/kafka:3.1.0-debian-10-r52
 	kind load docker-image milvusdb/etcd:3.5.0-r6

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ helm -n milvus-operator upgrade --install milvus-operator milvus-operator/milvus
 Or with kubectl & raw manifests:
 
 ```shell
-kubectl apply -f https://github.com/milvus-io/milvus-operator/v0.7.10/deploy/manifests/deployment.yaml
+kubectl apply -f https://github.com/milvus-io/milvus-operator/v0.7.9/deploy/manifests/deployment.yaml
 ```
 
 For more infomation Check [Installation Instructions](docs/installation/installation.md)
@@ -45,11 +45,11 @@ Versions of the underlying components are listed below:
 
 <!-- source csv for table
 Components, Milvus, Pulsar / Kafka, Etcd, MinIO
-Versions, v2.2.6 `[1]`, 2.8.2 / 3.1.0, 3.5.5-2, RELEASE.2023-03-20T20-16-18Z -->
+Versions, v2.2.5 `[1]`, 2.8.2 / 3.1.0, 3.5.5-2, RELEASE.2023-03-20T20-16-18Z -->
 
 |Components| Milvus| Pulsar / Kafka| Etcd| MinIO|
 |---|---|---|---|---|
-|Versions| v2.2.6 `[1]`| 2.8.2 / 3.1.0 | 3.5.5-2 |RELEASE.2023-03-20T20-16-18Z|
+|Versions| v2.2.5 `[1]`| 2.8.2 / 3.1.0 | 3.5.5-2 |RELEASE.2023-03-20T20-16-18Z|
 
 
 > `[1]` Version of milvus is the default version we will use, you can set it to other version. The Compatibility with milvus releases is showed below.
@@ -82,13 +82,13 @@ Use helm:
 ```shell
 helm upgrade --install milvus-operator \
   -n milvus-operator --create-namespace \
-  https://github.com/milvus-io/milvus-operator/releases/download/v0.7.10/milvus-operator-0.7.10.tgz
+  https://github.com/milvus-io/milvus-operator/releases/download/v0.7.9/milvus-operator-0.7.9.tgz
 ```
 
 Or use kubectl & raw manifests:
 
 ```shell
-kubectl apply -f https://raw.githubusercontent.com/milvus-io/milvus-operator/v0.7.10/deploy/manifests/deployment.yaml
+kubectl apply -f https://raw.githubusercontent.com/milvus-io/milvus-operator/v0.7.9/deploy/manifests/deployment.yaml
 ```
 
 

--- a/charts/milvus-operator/Chart.yaml
+++ b/charts/milvus-operator/Chart.yaml
@@ -18,13 +18,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.7.10
+version: 0.7.9
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.7.10"
+appVersion: "0.7.9"
 
 maintainers:
   - name: devops team of zilliz

--- a/charts/milvus-operator/values.yaml
+++ b/charts/milvus-operator/values.yaml
@@ -7,7 +7,7 @@ image:
   # image.pullPolicy -- The image pull policy for the controller.
   pullPolicy: IfNotPresent
   # image.tag -- The image tag whose default is the chart appVersion.
-  tag: "v0.7.10"
+  tag: "v0.7.9"
 
 # installCRDs -- If true, CRD resources will be installed as part of the Helm chart. If enabled, when uninstalling CRD resources will be deleted causing all installed custom resources to be DELETED
 installCRDs: true

--- a/deploy/manifests/deployment.yaml
+++ b/deploy/manifests/deployment.yaml
@@ -11,10 +11,10 @@ metadata:
   name: "milvus-operator"
   namespace: "milvus-operator"
   labels:
-    helm.sh/chart: milvus-operator-0.7.10
+    helm.sh/chart: milvus-operator-0.7.9
     app.kubernetes.io/name: milvus-operator
     app.kubernetes.io/instance: milvus-operator
-    app.kubernetes.io/version: "0.7.10"
+    app.kubernetes.io/version: "0.7.9"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: milvus-operator/templates/serviceaccount.yaml
@@ -24,10 +24,10 @@ metadata:
   name: "milvus-operator-checker"
   namespace: "milvus-operator"
   labels:
-    helm.sh/chart: milvus-operator-0.7.10
+    helm.sh/chart: milvus-operator-0.7.9
     app.kubernetes.io/name: milvus-operator
     app.kubernetes.io/instance: milvus-operator
-    app.kubernetes.io/version: "0.7.10"
+    app.kubernetes.io/version: "0.7.9"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: milvus-operator/templates/crds.yaml
@@ -14366,10 +14366,10 @@ kind: Service
 metadata:
   labels:
     service-kind: metrics
-    helm.sh/chart: milvus-operator-0.7.10
+    helm.sh/chart: milvus-operator-0.7.9
     app.kubernetes.io/name: milvus-operator
     app.kubernetes.io/instance: milvus-operator
-    app.kubernetes.io/version: "0.7.10"
+    app.kubernetes.io/version: "0.7.9"
     app.kubernetes.io/managed-by: Helm
   name: 'milvus-operator-metrics-service'
   namespace: "milvus-operator"
@@ -14387,10 +14387,10 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: milvus-operator-0.7.10
+    helm.sh/chart: milvus-operator-0.7.9
     app.kubernetes.io/name: milvus-operator
     app.kubernetes.io/instance: milvus-operator
-    app.kubernetes.io/version: "0.7.10"
+    app.kubernetes.io/version: "0.7.9"
     app.kubernetes.io/managed-by: Helm
   name: 'milvus-operator-webhook-service'
   namespace: "milvus-operator"
@@ -14409,10 +14409,10 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: milvus-operator-0.7.10
+    helm.sh/chart: milvus-operator-0.7.9
     app.kubernetes.io/name: milvus-operator
     app.kubernetes.io/instance: milvus-operator
-    app.kubernetes.io/version: "0.7.10"
+    app.kubernetes.io/version: "0.7.9"
     app.kubernetes.io/managed-by: Helm
   name: "milvus-operator"
   namespace: "milvus-operator"
@@ -14442,7 +14442,7 @@ spec:
         - --leader-elect
         command:
         - /manager
-        image: 'milvusdb/milvus-operator:v0.7.10'
+        image: 'milvusdb/milvus-operator:v0.7.9'
         imagePullPolicy: "IfNotPresent"
         livenessProbe:
           httpGet:
@@ -14497,10 +14497,10 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   labels:
-    helm.sh/chart: milvus-operator-0.7.10
+    helm.sh/chart: milvus-operator-0.7.9
     app.kubernetes.io/name: milvus-operator
     app.kubernetes.io/instance: milvus-operator
-    app.kubernetes.io/version: "0.7.10"
+    app.kubernetes.io/version: "0.7.9"
     app.kubernetes.io/managed-by: Helm
   name: "milvus-operator-checker"
   namespace: "milvus-operator"
@@ -14514,7 +14514,7 @@ spec:
       restartPolicy: OnFailure
       containers:
       - name: checker
-        image: 'milvusdb/milvus-operator:v0.7.10'
+        image: 'milvusdb/milvus-operator:v0.7.9'
         imagePullPolicy: "IfNotPresent"
         command: ["/checker"]
         args:

--- a/docs/installation/installation.md
+++ b/docs/installation/installation.md
@@ -12,7 +12,7 @@ For quick start, install with one line command:
 ```shell
 helm install milvus-operator \
   -n milvus-operator --create-namespace \
-  https://github.com/milvus-io/milvus-operator/releases/download/v0.7.10/milvus-operator-0.7.10.tgz
+  https://github.com/milvus-io/milvus-operator/releases/download/v0.7.9/milvus-operator-0.7.9.tgz
 ```
 
 If you already have `cert-manager` v1.0+ installed which is not in its default configuration, you may encounter some error with the check of cert-manager installation. you can install with special options to disable the check:
@@ -20,7 +20,7 @@ If you already have `cert-manager` v1.0+ installed which is not in its default c
 ```
 helm install milvus-operator \
   -n milvus-operator --create-namespace \
-  https://github.com/milvus-io/milvus-operator/releases/download/v0.7.10/milvus-operator-0.7.10.tgz \
+  https://github.com/milvus-io/milvus-operator/releases/download/v0.7.9/milvus-operator-0.7.9.tgz \
   --set checker.disableCertManagerCheck=true
 ```
 
@@ -39,7 +39,7 @@ use helm commands to upgrade earlier milvus-operator to current version:
 
 ```shell
 helm upgrade -n milvus-operator milvus-operator --reuse-values \
-  https://github.com/milvus-io/milvus-operator/releases/download/v0.7.10/milvus-operator-0.7.10.tgz
+  https://github.com/milvus-io/milvus-operator/releases/download/v0.7.9/milvus-operator-0.7.9.tgz
 ```
 
 ## Delete operator
@@ -62,7 +62,7 @@ If you don't want to use helm you can also install with kubectl and raw manifest
 ## Installation
 It is recommended to install the milvus operator with a newest stable version
 ```shell
-kubectl apply -f https://github.com/milvus-io/milvus-operator/v0.7.10/deploy/manifests/deployment.yaml
+kubectl apply -f https://github.com/milvus-io/milvus-operator/v0.7.9/deploy/manifests/deployment.yaml
 ``` 
 
 Check the installed operators:
@@ -85,7 +85,7 @@ Same as installation, you can update the milvus operator with a newer version by
 Delete the milvus operator stack by the deployment manifest:
 
 ```shell
-kubectl delete -f https://github.com/milvus-io/milvus-operator/v0.7.10/deploy/manifests/deployment.yaml
+kubectl delete -f https://github.com/milvus-io/milvus-operator/v0.7.9/deploy/manifests/deployment.yaml
 ```
 
 Or delete the milvus operator stack by using makefile:

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	DefaultMilvusVersion   = "v2.2.6"
+	DefaultMilvusVersion   = "v2.2.5"
 	DefaultMilvusBaseImage = "milvusdb/milvus"
 	DefaultMilvusImage     = DefaultMilvusBaseImage + ":" + DefaultMilvusVersion
 	DefaultImagePullPolicy = corev1.PullIfNotPresent


### PR DESCRIPTION
This reverts commit d92a82227f9f3337870cbd4fd626c4018df31da4.
/cc @zwd1208 