### PR TITLE
feat: Add PriorityClassName in Milvus CRDs

### DIFF
--- a/apis/milvus.io/v1beta1/components_types.go
+++ b/apis/milvus.io/v1beta1/components_types.go
@@ -84,6 +84,10 @@ type ComponentSpec struct {
 	// ServiceAccountName usually used for situations like accessing s3 with IAM role
 	// +kubebuilder:validation:Optional
 	ServiceAccountName string `json:"serviceAccountName,omitempty"`
+
+	// PriorityClassName indicates the pod's priority.
+	// +kubebuilder:validation:Optional
+	PriorityClassName string `json:"priorityClassName,omitempty"`
 }
 
 // ImageUpdateMode is how the milvus components' image should be updated. works only when rolling update is enabled.

--- a/config/crd/bases/milvus.io_milvusclusters.yaml
+++ b/config/crd/bases/milvus.io_milvusclusters.yaml
@@ -846,6 +846,8 @@ spec:
                         maximum: 65535
                         minimum: 0
                         type: integer
+                      priorityClassName:
+                        type: string
                       replicas:
                         format: int32
                         minimum: 0
@@ -1375,6 +1377,8 @@ spec:
                         maximum: 65535
                         minimum: 0
                         type: integer
+                      priorityClassName:
+                        type: string
                       replicas:
                         format: int32
                         minimum: 0
@@ -1986,6 +1990,8 @@ spec:
                         maximum: 65535
                         minimum: 0
                         type: integer
+                      priorityClassName:
+                        type: string
                       replicas:
                         format: int32
                         minimum: 0
@@ -2515,6 +2521,8 @@ spec:
                         maximum: 65535
                         minimum: 0
                         type: integer
+                      priorityClassName:
+                        type: string
                       replicas:
                         format: int32
                         minimum: 0
@@ -3046,6 +3054,8 @@ spec:
                         maximum: 65535
                         minimum: 0
                         type: integer
+                      priorityClassName:
+                        type: string
                       replicas:
                         format: int32
                         minimum: 0
@@ -3134,6 +3144,8 @@ spec:
                     additionalProperties:
                       type: string
                     type: object
+                  priorityClassName:
+                    type: string
                   proxy:
                     properties:
                       affinity:
@@ -3612,6 +3624,8 @@ spec:
                         maximum: 65535
                         minimum: 0
                         type: integer
+                      priorityClassName:
+                        type: string
                       replicas:
                         format: int32
                         minimum: 0
@@ -4156,6 +4170,8 @@ spec:
                         maximum: 65535
                         minimum: 0
                         type: integer
+                      priorityClassName:
+                        type: string
                       replicas:
                         format: int32
                         minimum: 0
@@ -4685,6 +4701,8 @@ spec:
                         maximum: 65535
                         minimum: 0
                         type: integer
+                      priorityClassName:
+                        type: string
                       replicas:
                         format: int32
                         minimum: 0
@@ -5233,6 +5251,8 @@ spec:
                         maximum: 65535
                         minimum: 0
                         type: integer
+                      priorityClassName:
+                        type: string
                       replicas:
                         format: int32
                         minimum: 0
@@ -5789,6 +5809,8 @@ spec:
                         maximum: 65535
                         minimum: 0
                         type: integer
+                      priorityClassName:
+                        type: string
                       replicas:
                         format: int32
                         minimum: 0

--- a/config/crd/bases/milvus.io_milvuses.yaml
+++ b/config/crd/bases/milvus.io_milvuses.yaml
@@ -791,6 +791,8 @@ spec:
                 additionalProperties:
                   type: string
                 type: object
+              priorityClassName:
+                type: string
               replicas:
                 format: int32
                 type: integer
@@ -1872,6 +1874,8 @@ spec:
                         maximum: 65535
                         minimum: 0
                         type: integer
+                      priorityClassName:
+                        type: string
                       replicas:
                         format: int32
                         minimum: 0
@@ -2401,6 +2405,8 @@ spec:
                         maximum: 65535
                         minimum: 0
                         type: integer
+                      priorityClassName:
+                        type: string
                       replicas:
                         format: int32
                         minimum: 0
@@ -3012,6 +3018,8 @@ spec:
                         maximum: 65535
                         minimum: 0
                         type: integer
+                      priorityClassName:
+                        type: string
                       replicas:
                         format: int32
                         minimum: 0
@@ -3541,6 +3549,8 @@ spec:
                         maximum: 65535
                         minimum: 0
                         type: integer
+                      priorityClassName:
+                        type: string
                       replicas:
                         format: int32
                         minimum: 0
@@ -4072,6 +4082,8 @@ spec:
                         maximum: 65535
                         minimum: 0
                         type: integer
+                      priorityClassName:
+                        type: string
                       replicas:
                         format: int32
                         minimum: 0
@@ -4160,6 +4172,8 @@ spec:
                     additionalProperties:
                       type: string
                     type: object
+                  priorityClassName:
+                    type: string
                   proxy:
                     properties:
                       affinity:
@@ -4638,6 +4652,8 @@ spec:
                         maximum: 65535
                         minimum: 0
                         type: integer
+                      priorityClassName:
+                        type: string
                       replicas:
                         format: int32
                         minimum: 0
@@ -5182,6 +5198,8 @@ spec:
                         maximum: 65535
                         minimum: 0
                         type: integer
+                      priorityClassName:
+                        type: string
                       replicas:
                         format: int32
                         minimum: 0
@@ -5711,6 +5729,8 @@ spec:
                         maximum: 65535
                         minimum: 0
                         type: integer
+                      priorityClassName:
+                        type: string
                       replicas:
                         format: int32
                         minimum: 0
@@ -6259,6 +6279,8 @@ spec:
                         maximum: 65535
                         minimum: 0
                         type: integer
+                      priorityClassName:
+                        type: string
                       replicas:
                         format: int32
                         minimum: 0
@@ -6815,6 +6837,8 @@ spec:
                         maximum: 65535
                         minimum: 0
                         type: integer
+                      priorityClassName:
+                        type: string
                       replicas:
                         format: int32
                         minimum: 0

--- a/pkg/controllers/components.go
+++ b/pkg/controllers/components.go
@@ -554,5 +554,9 @@ func MergeComponentSpec(src, dst ComponentSpec) ComponentSpec {
 		dst.ServiceAccountName = src.ServiceAccountName
 	}
 
+	if len(src.PriorityClassName) > 0 {
+		dst.PriorityClassName = src.PriorityClassName
+	}
+
 	return dst
 }

--- a/pkg/controllers/components_test.go
+++ b/pkg/controllers/components_test.go
@@ -213,6 +213,15 @@ func TestMergeComponentSpec(t *testing.T) {
 		merged = MergeComponentSpec(src, dst).ServiceAccountName
 		assert.Equal(t, "b", merged)
 	})
+
+	t.Run("merge priorityClassName", func(t *testing.T) {
+		dst.PriorityClassName = "a"
+		merged := MergeComponentSpec(src, dst).PriorityClassName
+		assert.Equal(t, "a", merged)
+		src.PriorityClassName = "b"
+		merged = MergeComponentSpec(src, dst).PriorityClassName
+		assert.Equal(t, "b", merged)
+	})
 }
 
 func TestMilvusComponent_GetReplicas(t *testing.T) {

--- a/pkg/controllers/deployment_updater.go
+++ b/pkg/controllers/deployment_updater.go
@@ -107,6 +107,7 @@ func updateDeployment(deployment *appsv1.Deployment, updater deploymentUpdater) 
 	template.Spec.NodeSelector = mergedComSpec.NodeSelector
 	template.Spec.ImagePullSecrets = mergedComSpec.ImagePullSecrets
 	template.Spec.ServiceAccountName = mergedComSpec.ServiceAccountName
+	template.Spec.PriorityClassName = mergedComSpec.PriorityClassName
 	// update component container
 	containerIdx := GetContainerIndex(template.Spec.Containers, updater.GetComponentName())
 	if containerIdx < 0 {

--- a/pkg/util/k8s_client_test.go
+++ b/pkg/util/k8s_client_test.go
@@ -208,7 +208,7 @@ spec:
     spec:
       containers:
       - name: pause
-        image: kubernetes/pause:asm
+        image: nginx:latest
         resources:
           limits:
             memory: "64Mi"


### PR DESCRIPTION
This PR allows users to specify `priorityClassName` for the deployments of different components.